### PR TITLE
Facebook module added

### DIFF
--- a/airframe/airframe.py
+++ b/airframe/airframe.py
@@ -153,8 +153,10 @@ class AirFrame(object):
         size = [int(x) for x in tuple(size)]
         for infile in photo_filenames:
             im = Image.open(infile)
-            im.thumbnail(size, Image.ANTIALIAS)
-            im.save(infile)
+            if im.size[0] > size[0] or im.size[1] > size[1]:
+                im.thumbnail(size, Image.ANTIALIAS)
+                im.save(infile)
+            im.close()
 
 
     def go(self, argv):

--- a/airframe/airframe.py
+++ b/airframe/airframe.py
@@ -23,6 +23,8 @@ import shutil
 from version import __version__
 from flickr import Flickr
 from flashair import FlashAir
+from facebookphotos import FacebookPhotos
+from PIL import Image
 
 class AirFrame(object):
 
@@ -51,12 +53,21 @@ class AirFrame(object):
             :ivar verbose: Enable verbose logging
         """
         p = argparse.ArgumentParser(
-                description = "Push pictures from Flickr or local files to a Toshiba FlashAir automatically",
+                description = "Push pictures from Flickr, Facebook or local files to a Toshiba FlashAir automatically",
                 epilog = "AirFrame version %s (Copyright 2014 Virantha Ekanayake)" % __version__,
                 )
 
+        p.add_argument('-b', '--facebook', action='store_true',
+            default=False, help='Upload pictures from Flickr to Flashair')
+
+        p.add_argument('-r', '--flickr', action='store_true',
+            default=True, help='Upload pictures from Facebook to Flashair (default)')
+
         p.add_argument('-l', '--local-dir', type=str,
-            help='Upload all .jpg files from this directory instead of Flickr')
+            help='Upload all .jpg files from this directory instead of Flickr or Facebook')
+        
+        p.add_argument('-s', '--resize', type=str,
+            help='Resize all images to fit in this box (e.g. 1024x768) before uploading them to Flashair')
 
         p.add_argument('-d', '--debug', action='store_true',
             default=False, dest='debug', help='Turn on debugging')
@@ -71,7 +82,7 @@ class AirFrame(object):
             default=100, dest='number', help='Max number of photos to sync')
 
         p.add_argument('-t', '--tags', type=self._parse_csv_list,
-                default=[], dest='tags', help='List of tags to match')
+                default=[], dest='tags', help='List of Flickr tags to match')
 
         p.add_argument('flashair_ip', type=str,
                         help='The ip/hostname of your FlashAir card')
@@ -86,6 +97,9 @@ class AirFrame(object):
         self.force_upload = args.force
         self.flashair_ip = args.flashair_ip
         self.local_dir = args.local_dir
+        self.resize = args.resize
+        self.facebook = args.facebook
+        self.flickr = args.flickr
 
         if self.debug:
             logging.basicConfig(level=logging.DEBUG, format='%(message)s')
@@ -101,6 +115,17 @@ class AirFrame(object):
             photo_filenames = self.flickr.get_tagged(self.photo_tags, self.photo_count, download_dir=self.download_dir)
         else:
             photo_filenames = self.flickr.get_recent(self.photo_count,download_dir=self.download_dir)
+        return photo_filenames
+
+    def facebook_mode(self):
+        # Connect to Facebook
+        logging.debug("list of tags: %s" % self.photo_tags)
+        self.facebookphotos = FacebookPhotos()
+#        if len(self.photo_tags) > 0:
+#            photo_filenames = self.flickr.get_tagged(self.photo_tags, self.photo_count, download_dir=self.download_dir)
+#        else:
+#            photo_filenames = self.flickr.get_recent(self.photo_count,download_dir=self.download_dir)
+        photo_filenames = self.facebookphotos.get_recent(self.photo_count,download_dir=self.download_dir)
         return photo_filenames
 
     def local_dir_mode(self):
@@ -122,14 +147,29 @@ class AirFrame(object):
             shutil.copy(filename, self.download_dir)
         return photo_filenames    
 
+    def resize_pictures(self, photo_filenames):
+        print 'Resizing images...'
+        size = self.resize.split('x')
+        size = [int(x) for x in tuple(size)]
+        for infile in photo_filenames:
+            im = Image.open(infile)
+            im.thumbnail(size, Image.ANTIALIAS)
+            im.save(infile)
+
+
     def go(self, argv):
         self.download_dir = ".airframe"
         self.get_options(argv)
 
         if self.local_dir:
             photo_filenames = self.local_dir_mode()
+        elif self.facebook:
+            photo_filenames = self.facebook_mode()
         else:
             photo_filenames = self.flickr_mode()
+
+        if self.resize:
+            self.resize_pictures(photo_filenames)
 
         self.flashair = FlashAir(self.flashair_ip)
         self.flashair.sync_files_on_card_to_list(photo_filenames, self.force_upload)

--- a/airframe/facebookphotos.py
+++ b/airframe/facebookphotos.py
@@ -48,8 +48,7 @@ class FacebookPhotos(object):
 
     def __init__(self):
         self.set_keys(*self.read_keys())
-        #self.get_auth2()
-#        self.refresh_token()
+        self.refresh_token()
 
     def read_keys(self):
         """
@@ -70,10 +69,6 @@ class FacebookPhotos(object):
         with open('facebook_api.yaml', 'w') as outfile:
             outfile.write(yaml.dump(data, default_flow_style=False))
             outfile.close()
-
-#    def get_auth2(self):
-#        self.token = facebook.get_app_access_token(self.app_id, self.app_secret)
-#        print self.token
  
     def refresh_token(self):
         new_token = None

--- a/airframe/facebookphotos.py
+++ b/airframe/facebookphotos.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright 2013 Virantha Ekanayake All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys, os
+import logging
+
+import yaml
+import facebook
+import urllib
+import urlparse
+
+
+SAFE_CHARS = '-_() abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+
+class Photo(object):
+    def __init__(self, photo_element):
+        """Construct a photo object out of the JSON response from Facebook"""
+        attrs = { 'source': 'source', 'photoid':'photoid'}
+        for fb_attr, py_attr in attrs.items():
+            setattr(self, fb_attr, photo_element.get(fb_attr))
+
+    def download_photo(self, dirname, cache=False, tgt_filename=None):
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
+        tgt = os.path.join(dirname, "%s.jpg" % self.photoid)
+        if cache:
+            if os.path.isfile(tgt):
+                return tgt
+        urllib.urlretrieve(self.source, tgt)
+        return tgt
+        
+class FacebookPhotos(object):
+
+    def __init__(self):
+        self.set_keys(*self.read_keys())
+        #self.get_auth2()
+        self.refresh_token()
+
+    def read_keys(self):
+        """
+            Read the Facebook API App ID and App Secret from a local file
+        """
+        with open("facebook_api.yaml") as f:
+            api = yaml.load(f)
+        return (api["app_id"], api["app_secret"], api["client_token"],  api["access_token"])
+
+    def set_keys(self, app_id, app_secret, client_token, access_token):
+        self.app_id = app_id
+        self.app_secret = app_secret
+        self.client_token = client_token
+        self.access_token = access_token
+        print app_id, app_secret, client_token, access_token
+
+    def write_keys(self):
+        data = {'app_id': self.app_id, 'app_secret': self.app_secret, 'client_token': self.client_token, 'access_token': self.access_token}
+        with open('facebook_api.yaml', 'w') as outfile:
+            outfile.write(yaml.dump(data, default_flow_style=False))
+            outfile.close()
+
+#    def get_auth2(self):
+#        self.token = facebook.get_app_access_token(self.app_id, self.app_secret)
+#        print self.token
+ 
+    def refresh_token(self):
+        new_token = None
+        """
+            Gets a new long-lived token using the current long-lived token.
+            See http://nodotcom.org/python-facebook-tutorial.html for reference.
+        """
+        url = 'https://graph.facebook.com/oauth/access_token?client_id=%s&client_secret=%s&grant_type=fb_exchange_token&fb_exchange_token=%s' % (self.app_id, self.app_secret, self.access_token)
+        response = urllib.urlopen(url)
+        oauth = response.read()
+        try:
+            new_token = urlparse.parse_qs(oauth)['access_token'][0]
+            self.access_token = new_token
+            self.write_keys()
+        except:
+            print 'Failed to retrieve and store a new long-lived token.'
+        response.close()
+
+    def _sync_photos(self, photos, download_dir="photos", clean_up=False):
+        """
+            Connect to Facebook, and for each photo in the list, download.
+            Then, if deleted photos that are present locally that weren't present in the list of photos.
+
+            :returns: List of filenames downloaded
+        """
+        photo_filenames = []
+        photo_count = len(photos)
+        for i,photo in enumerate(photos):
+            print("[%d/%d] Downloading %s from Facebook" % (i,photo_count,photo.photoid))
+            filename = photo.download_photo(download_dir, cache=True)
+            photo_filenames.append(filename)
+
+        # Now, go through and clean up directory if required
+        
+        if clean_up:
+            photo_file_list = ["%s.jpg" % (x.photoid) for x in photos]
+            for fn in os.listdir(download_dir):
+                full_fn = os.path.join(download_dir, fn)
+                if os.path.isfile(full_fn):
+                    if not fn in photo_file_list:
+                        print ("Facebook sync: Deleting file %s" % fn)
+                        os.remove(full_fn)
+
+        return photo_filenames
+
+    def _extract_photos_from_json(self, dat):
+        """Extract required data from a row"""
+        err = []
+        photos = []
+        for d in dat:
+            if 'source' not in d:
+                err.append(d)
+                continue
+            source = d['source']
+            if 'id' not in d:
+                err.append(d)
+                continue
+            photoid = d['id']
+            photos.append(Photo({'source': source, 'photoid': photoid}))
+        if err:
+            print '%d errors.' % len(err)
+            print err
+        return photos
+
+    def get_recent(self, count, download_dir="photos"):
+        depth=10
+        
+        """Fetch the data using Facebook's Graph API"""
+        photo_filenames = []
+        graph = facebook.GraphAPI(self.access_token)
+#        url = 'me/photos/uploaded' #% id
+        url = 'me/photos/'
+        photos = []
+
+        args = {'fields': ['source', 'photoid'], 'limit': count}
+        res = graph.request(url, args)
+        photos.extend(self._extract_photos_from_json(res['data']))
+    
+        # continue fetching till all photos are found
+        for _ in xrange(depth):
+            if 'paging' not in res:
+                break
+            try:
+                url = res['paging']['next']
+                res = json.loads(urllib.urlopen(url).read())
+                photos.extend(self._extract_photos_from_json(res['data']))
+            except:
+                break
+            
+        photo_filenames = self._sync_photos(photos, download_dir)
+        return photo_filenames
+
+def main():
+    #logging.basicConfig(level=logging.DEBUG, format='%(message)s')
+    script = FacebookPhotos()
+#    key,secret = script.read_keys()
+#    script.set_keys(key,secret)
+#    script.get_auth2()
+    script.get_recent(10)
+
+
+if __name__ == '__main__':
+    main()

--- a/airframe/flashair.py
+++ b/airframe/flashair.py
@@ -54,7 +54,7 @@ class FlashAir(object):
         payload = {"op":100, "DIR":self.card_path}
         r = requests.get("http://%s/command.cgi" % self.hostname, params=payload)
         r.raise_for_status()
-        print r.text
+        logging.debug("Response: %s" % r.text)
         # Divide the returned text by newline, and ignore the first line "WLANSD_FILELIST"
         lines = r.text.split('\n')
         assert lines[0].strip()=='WLANSD_FILELIST'
@@ -67,7 +67,7 @@ class FlashAir(object):
                 filename = values[1].strip()
                 filenames.append(filename)
 
-        print filenames
+        logging.debug("File names: %s" % filenames)
         return filenames
 
     def _get_renamed_filename(self, filename):


### PR DESCRIPTION
As I do not actively use Flickr, but Facebook instead, I have added a module to retrieve pictures from there. Setting things up on the Facebook-side is a bit of a hassle, as you need to create a new application to get API keys etc. But once it's set up, it works like a charm.
I might add further features, e.g. downloading from specific photo albums etc.

Also, I have added a resize function which resizes pictures before they are uploaded to the digital picture frame. 3 reasons:
- reduce file size
- thereby improve upload speed
- improve visual appearance -- my digital picture frame displays ugly artifacts when it needs to resize pictures to fit its native resolution.

The default behaviour should not have changed, e.g. if you are using Flickr, you can also use this version without worrying about your configuration.