### PR TITLE
Enlargen images to fit target resolution

### DIFF
--- a/airframe/airframe.py
+++ b/airframe/airframe.py
@@ -156,6 +156,15 @@ class AirFrame(object):
             if im.size[0] > size[0] or im.size[1] > size[1]:
                 im.thumbnail(size, Image.ANTIALIAS)
                 im.save(infile)
+            elif im.size[0] < size[0] and im.size[1] < size[1]:
+                width_factor = float(size[0])/im.size[0]
+                height_factor = float(size[1])/im.size[1]
+                target_factor = min(height_factor, width_factor)
+                target_width = int(im.size[0]*target_factor)
+                target_height = int(im.size[1]*target_factor)
+                result = im.resize((target_width, target_height), Image.BICUBIC)
+                result.save(infile)
+                result.close()
             im.close()
 
 


### PR DESCRIPTION
...keeping their aspect ratio, if they are too small.
In the previous version, images would only be resized if they were larger than the target resolution. In the rare case that a picture is smaller than the target resolution (i.e. height AND width are too small), wer're enlargen them to the maximum sane size.
Example:
Source resolution: 400x600 px
Target resolution: 1024x768 (native resolution of the digital picture frame)
=> the picture will be resized to 512x768

This is based on #5, but from a feature-branch.